### PR TITLE
[#9] Add a list of available operators to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ mapLatter |  [mapLatter](https://github.com/rxjsx/rxjsx/tree/master/docs/operato
 flatMapFormer | [flatMapFormer](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#flatmapformer) |
 flatMapLatter |  [flatMapLatter](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#flatmaplatter) |
 listMap | [listMap](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#listmap) |
-flatListMap | flatListMap](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#flatlistmap) |
-listFlatMap | listFlatMap](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#listflatmap) |
-flatListFlatMap |  flatListFlatMap](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#flatlistflatmap) |
+flatListMap | [flatListMap](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#flatlistmap) |
+listFlatMap | [listFlatMap](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#listflatmap) |
+flatListFlatMap |  [flatListFlatMap](https://github.com/rxjsx/rxjsx/tree/master/docs/operators#flatlistflatmap) |


### PR DESCRIPTION
https://github.com/rxjsx/rxjsx/issues/9
Currently, descriptive documentation of the available operators exists in a deeper README file. We should create a table on the main README that contains all the operators in rows with links to their descriptions in the other README file.

The table can have only one column in the first PR. A second column with short descriptions can be added in a separate pull request.